### PR TITLE
Deadlink causing error when downloading yolov7 release .pt

### DIFF
--- a/yolov7/utils/google_utils.py
+++ b/yolov7/utils/google_utils.py
@@ -23,7 +23,7 @@ def attempt_download(file, repo='WongKinYiu/yolov7'):
 
     if not file.exists():
         try:
-            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            response = requests.get(f'https://api.github.com/repos/{repo}/releases/tags/v0.1').json()  # github api
             assets = [x['name'] for x in response['assets']]  # release assets
             tag = response['tag_name']  # i.e. 'v1.0'
         except:  # fallback plan


### PR DESCRIPTION
**Before:**
https://api.github.com/repos/WongKinYiu/yolov7/releases/latest  
which shows: 
```
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/releases/releases#get-the-latest-release"
}
```

This is causing error:
```
Traceback (most recent call last):
  File "./yolov7/utils/google_utils.py", line 27, in attempt_download
    assets = [x['name'] for x in response['assets']]  # release assets
KeyError: 'assets'
```

Switch it to `/tags/v0.1` to solve it!
https://api.github.com/repos/WongKinYiu/yolov7/releases/tags/v0.1